### PR TITLE
Fix startup script JVM options

### DIFF
--- a/doc/panako
+++ b/doc/panako
@@ -4,7 +4,7 @@
 #
 #   2014.01.31 - Panako startup bash script.
 # 	It assumes that a working JVM is present on the system.
-#	Please consult the manual for more info. 
+#	Please consult the manual for more info.
 #
 ############################################################
 
@@ -12,7 +12,7 @@
 PANAKO_DIR="/opt/panako"
 
 #Some parameters for the JVM to improve performance
-PANAKO_JVM_OPTIONS="-server -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Xms256m -Xmx256m"
+PANAKO_JVM_OPTS="-server -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Xms256m -Xmx256m"
 
 #The configuration file to configure logging
 LOG_CONFIGURATION="$PANAKO_DIR/logging.properties"


### PR DESCRIPTION
This gets relevant if you are working with larger datasets. Just fixing this typo that the JVM options can actually be used.