### PR TITLE
Correct f1LargerThanF2 condition from copy&paste issue

### DIFF
--- a/src/be/panako/strategy/panako/PanakoFingerprint.java
+++ b/src/be/panako/strategy/panako/PanakoFingerprint.java
@@ -105,7 +105,7 @@ public class PanakoFingerprint {
 	public int robustHash(){
 		int hash = 0;
 		
-		int f1LargerThanF2 = f2 > f3 ? 1 : 0;
+		int f1LargerThanF2 = f1 > f2 ? 1 : 0;
 		int f2LargerThanF3 = f2 > f3 ? 1 : 0;
 		int f3LargerThanF1 = f3 > f1 ? 1 : 0;
 

--- a/src/be/panako/strategy/panako/PanakoFingerprint.java
+++ b/src/be/panako/strategy/panako/PanakoFingerprint.java
@@ -168,7 +168,7 @@ public class PanakoFingerprint {
 			return hash;
 		//else
 		
-		long f1LargerThanF2 = f2 > f3 ? 1 : 0;
+		long f1LargerThanF2 = f1 > f2 ? 1 : 0;
 		long f2LargerThanF3 = f2 > f3 ? 1 : 0;
 		long f3LargerThanF1 = f3 > f1 ? 1 : 0;
 


### PR DESCRIPTION
While porting some of the code found a typo, probably from a copy&paste error.
Variable name `f1LargerThanF2` and code context do show what the correct change should be.