### PR TITLE
Fix string format specifier in error message for checkFileSize

### DIFF
--- a/src/main/java/be/panako/util/FileUtils.java
+++ b/src/main/java/be/panako/util/FileUtils.java
@@ -525,7 +525,7 @@ public final class FileUtils {
 		if(fileSizeInBytes != 0 && fileSizeInMB < maxFileSizeInMB ){
 			fileOk = true;
 		}else{
-			String message = String.format("Could not process %s it has an unacceptable file size of %l MB  (zero or larger than  %d MB ).", file.getName(), fileSizeInMB, maxFileSizeInMB );
+			String message = String.format("Could not process %s it has an unacceptable file size of %d MB  (zero or larger than  %d MB ).", file.getName(), fileSizeInMB, maxFileSizeInMB );
 			LOG.warning(message);
 			System.err.println(message);
 		}


### PR DESCRIPTION
Fix string format specifier in error message for `FileUtils.checkFileSize()`

The `%l` conversion specifier is not applicable for Java integral values, it will throw `IllegalFormatException`, so `%d` should be used instead.
See https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Formatter.html#syntax